### PR TITLE
Added CMake capability to reckless

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,40 @@
+project(reckless)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
+
+################################################################################
+# Add Flags
+################################################################################
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_FLAGS "-Wall -Wextra -O3 -g")
+
+
+
+################################################################################
+# Build Libraries
+################################################################################
+include_directories("boost")
+include_directories("reckless/include")
+
+add_library(reckless STATIC
+reckless/src/thread_input_buffer.cpp
+reckless/src/output_buffer.cpp
+reckless/src/ntoa.cpp
+reckless/src/crash_handler.cpp
+reckless/src/template_formatter.cpp
+reckless/src/writer.cpp
+reckless/src/basic_log.cpp
+reckless/src/policy_log.cpp
+reckless/src/file_writer.cpp
+reckless/src/posix_error_category.cpp
+reckless/src/utility.cpp
+reckless/src/fd_writer.cpp
+)
+
+
+
+################################################################################
+# Build Examples
+################################################################################
+message (STATUS "Making example applications")
+add_subdirectory(examples)
+

--- a/README.md
+++ b/README.md
@@ -123,13 +123,38 @@ a patch or buys me hardware.
 
 Building
 ========
-To build the library, clone the git repository and run make.
+
+1.Using Make
+------------
+To build the library using Make, clone the git repository and run make.
 
 To build a program against the library, given the variable RECKLESS
 pointing to the reckless root directory, use:
 
 ```bash
 g++ -std=c++11 myprogram.cpp -I$(RECKLESS)/boost -I$(RECKLESS)/reckless/include -L$(RECKLESS)/reckless/lib -lreckless -lpthread
+```
+
+2.Using CMake
+-------------
+To build the library using CMake, clone the git repository and run the following commands:
+
+```
+mkdir build; cd build
+cmake ..
+make
+```
+
+To build a program against this library using CMake, add the following line to your program's CMakeLists.txt:
+
+```
+add_subdirectory(path/to/reckless)
+```
+
+Subsequently, to link this library to a program (e.g. **your_executable**), add the following to your program's CMakeLists.txt:
+
+```
+target_link_libraries(your_executable reckless pthread)
 ```
 
 More information

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,20 @@
+project(reckless_examples)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
+
+
+
+################################################################################
+# Build Examples
+################################################################################
+add_executable(severity_log severity_log.cpp )
+target_link_libraries(severity_log reckless pthread)
+
+add_executable(stderr_log stderr_log.cpp )
+target_link_libraries(stderr_log reckless pthread)
+
+add_executable(ucs2_log ucs2_log.cpp )
+target_link_libraries(ucs2_log reckless pthread)
+
+add_executable(custom_formatter custom_formatter.cpp )
+target_link_libraries(custom_formatter reckless pthread)
+


### PR DESCRIPTION
* CMakeLists.txt
> Rewrote Makefile to CMake to build the library itself

* examples/CMakeLists.txt
> Splitted the compilation of example applications into another file that centres around building application using the compiled library

* README.md
> Documented how to compile and incorporate reckless to other applications using CMake