### PR TITLE
conan recipe for reckless lib

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -6,10 +6,10 @@ from conans import ConanFile, tools, CMake
 
 class RecklessConan(ConanFile):
     name = 'reckless'
-    version = '3.0.0'
     license = 'Boost Software License - Version 1.0 - August 17th, 2003'
     url = 'https://github.com/mattiasflodin/reckless'
-    description = """performant logging library in C++"""
+    description = """Reckless is an extremely low-latency, high-throughput logging library."""
+    
     settings = 'arch', 'cppstd', 'compiler', 'build_type'
     
     _build_subfolder = 'build'

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os, shutil
+from conans import ConanFile, tools, CMake
+
+class RecklessConan(ConanFile):
+    name = 'reckless'
+    version = '3.0.0'
+    license = 'Boost Software License - Version 1.0 - August 17th, 2003'
+    url = 'https://github.com/mattiasflodin/reckless'
+    description = """performant logging library in C++"""
+    settings = 'arch', 'cppstd', 'compiler', 'build_type'
+    
+    _build_subfolder = 'build'
+    _source_subfolder = 'src'
+
+    def configure(self):
+        pass
+    
+    def source(self):
+        tools.get('%s/archive/v%s.tar.gz' % (self.url, self.version))
+        shutil.move('reckless-%s' % self.version, self._source_subfolder)
+
+    def _configure_cmake(self):
+
+        cmake = CMake(self)
+        cmake.configure(build_folder=self._build_subfolder, source_folder=self._source_subfolder)
+        return cmake
+
+    def build(self):
+        os.makedirs(self._build_subfolder)
+        with tools.chdir(self._build_subfolder):
+            cmake = self._configure_cmake()
+            cmake.build()
+
+    
+    def package(self):
+        
+        self.copy('*.a', src='build', dst='lib', keep_path=False)
+        self.copy('*.lib', src='build', dst='lib', keep_path=False)
+        self.copy('*.hpp', src='src/reckless/include', dst='include', keep_path=True)
+
+        if self.settings.build_type == 'Debug':
+            self.copy('*.cpp', src='src/reckless/src', dst='src', keep_path=True)
+            self.copy('*.pdb', src='build', dst='lib', keep_path=False)        
+
+    def package_info(self):
+        self.cpp_info.libs = ["reckless"]
+        pass

--- a/conanfile.py
+++ b/conanfile.py
@@ -6,10 +6,10 @@ from conans import ConanFile, tools, CMake
 
 class RecklessConan(ConanFile):
     name = 'reckless'
-    license = 'Boost Software License - Version 1.0 - August 17th, 2003'
+    license = 'Copyright 2015-2020 Mattias Flodin <git@codepentry.com>'
     url = 'https://github.com/mattiasflodin/reckless'
     description = """Reckless is an extremely low-latency, high-throughput logging library."""
-    
+
     settings = 'arch', 'cppstd', 'compiler', 'build_type'
     
     _build_subfolder = 'build'
@@ -44,6 +44,8 @@ class RecklessConan(ConanFile):
         if self.settings.build_type == 'Debug':
             self.copy('*.cpp', src='src/reckless/src', dst='src', keep_path=True)
             self.copy('*.pdb', src='build', dst='lib', keep_path=False)        
+
+        self.copy('LICENSE.txt', src='src')
 
     def package_info(self):
         self.cpp_info.libs = ["reckless"]

--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ class RecklessConan(ConanFile):
     license = 'Copyright 2015-2020 Mattias Flodin <git@codepentry.com>'
     url = 'https://github.com/mattiasflodin/reckless'
     description = """Reckless is an extremely low-latency, high-throughput logging library."""
-
+    generators = 'cmake'
     settings = 'arch', 'cppstd', 'compiler', 'build_type'
     
     _build_subfolder = 'build'


### PR DESCRIPTION
Hi, 
Here is a PR to add up a conan recipe for reckless. 

I managed to build the package using centos/gcc8+ and Windows/vc142. Other arch/compiler would have to be tested separately.

I've been also able to import the lib in a snippet project in Linux using cmake/conan_cmake_run, but the default cmake generator is available so the simpler conan_basic_setup should work out of the box.

I only tried to build the latest 3.0.0 version, but other versions would be handled through the package create command:
```
conan create . reckless/X.Y.Z@someuser/stable
```
Let me know if you have questions.

Jean-Mathieu Vermosen