### PR TITLE
guard compilation of examples with a cmake variable to make it optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,11 @@ endif()
 project(reckless LANGUAGES CXX)
 CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 
+################################################################################
+# Options
+################################################################################
+
+option(RECKLESS_BUILD_EXAMPLES "Build the examples" OFF)
 
 ################################################################################
 # Add Flags
@@ -52,5 +57,8 @@ add_library(reckless STATIC ${SRC_LIST})
 ################################################################################
 # Build Examples
 ################################################################################
-message (STATUS "Making example applications")
-add_subdirectory(examples)
+if (RECKLESS_BUILD_EXAMPLES)
+    message (STATUS "Making example applications")
+    add_subdirectory(examples)
+endif ()
+


### PR DESCRIPTION
the idea is to not force compilation of the examples.

added RECKLESS_BUILD_EXAMPLES cmake variable that can be set to build the examples.

it is off by default to make builds fast by default